### PR TITLE
Memcache colission

### DIFF
--- a/config-templates/config.php
+++ b/config-templates/config.php
@@ -765,6 +765,17 @@ $config = array(
 
 
     /*
+     * This value allows you to set a prefix for memcache-keys. The default
+     * for this value is 'simpleSAMLphp', which is fine in most cases.
+     *
+     * When running multiple instances of SSP on the same host, and more
+     * than one instance is using memcache, you probably want to assign
+     * a unique value per instance to this setting to avoid data collision.
+     */
+    'memcache_store.prefix' => null,
+
+
+    /*
      * This value is the duration data should be stored in memcache. Data
      * will be dropped from the memcache servers when this time expires.
      * The time will be reset every time the data is written to the

--- a/lib/SimpleSAML/Store/Memcache.php
+++ b/lib/SimpleSAML/Store/Memcache.php
@@ -10,7 +10,20 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store
     /**
      * Initialize the memcache datastore.
      */
+
+    /**
+     * This variable contains the session name prefix.
+     *
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * This function implements the constructor for this class. It loads the Memcache configuration.
+     */
     protected function __construct() {
+        $config = SimpleSAML_Configuration::getInstance();
+        $this->prefix = $config->getString('memcache_store.name', 'simpleSAMLphp');
     }
 
 
@@ -26,7 +39,7 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store
         assert('is_string($type)');
         assert('is_string($key)');
 
-        return SimpleSAML_Memcache::get('simpleSAMLphp.' . $type . '.' . $key);
+        return SimpleSAML_Memcache::get($this->prefix . '.' . $type . '.' . $key);
     }
 
 
@@ -48,7 +61,7 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store
             $expire = 0;
         }
 
-        SimpleSAML_Memcache::set('simpleSAMLphp.' . $type . '.' . $key, $value, $expire);
+        SimpleSAML_Memcache::set($this->prefix . '.' . $type . '.' . $key, $value, $expire);
     }
 
 
@@ -63,6 +76,6 @@ class SimpleSAML_Store_Memcache extends SimpleSAML_Store
         assert('is_string($type)');
         assert('is_string($key)');
 
-        SimpleSAML_Memcache::delete('simpleSAMLphp.' . $type . '.' . $key);
+        SimpleSAML_Memcache::delete($this->prefix . '.' . $type . '.' . $key);
     }
 }


### PR DESCRIPTION
This change is to prevent data collision when running multiple SSP-instances on one host and more than one of then is configured to use memcache.
A prefix that allows you to distinguish memcache-data over instances can now be set.